### PR TITLE
Add minimal NES emulator skeleton

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+CXX=g++
+CXXFLAGS=-std=c++17 -Wall -O2
+
+OBJS=c6502.o NesBus.o main.o
+
+all: nes_emulator
+
+nes_emulator: $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $(OBJS)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) nes_emulator
+
+.PHONY: clean

--- a/NesBus.cpp
+++ b/NesBus.cpp
@@ -1,0 +1,29 @@
+#include "NesBus.h"
+#include "c6502.h"
+
+NesBus::NesBus(const std::vector<uint8_t> &prg) : prg_rom(prg) {}
+
+uint8_t NesBus::read(c6502 *cpu, Addr address, bool sync)
+{
+    (void)cpu;
+    (void)sync;
+    if (address < 0x2000) {
+        return ram[address & 0x07FF];
+    } else if(address >= 0x8000) {
+        if(prg_rom.empty()) return 0;
+        size_t offset = address - 0x8000;
+        if(prg_rom.size() == 16384)
+            offset %= 16384;
+        if(offset < prg_rom.size())
+            return prg_rom[offset];
+    }
+    return 0;
+}
+
+void NesBus::write(c6502 *cpu, Addr address, uint8_t data)
+{
+    (void)cpu;
+    if(address < 0x2000) {
+        ram[address & 0x07FF] = data;
+    }
+}

--- a/NesBus.h
+++ b/NesBus.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Bus.h"
+#include <array>
+#include <vector>
+
+class NesBus : public Bus {
+public:
+    explicit NesBus(const std::vector<uint8_t> &prg);
+
+    uint8_t read(c6502 *cpu, Addr address, bool sync = false) override;
+    void write(c6502 *cpu, Addr address, uint8_t data) override;
+
+private:
+    std::vector<uint8_t> prg_rom;
+    std::array<uint8_t, 2 * 1024> ram{};
+};

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,46 @@
+#include "c6502.h"
+#include "NesBus.h"
+
+#include <fstream>
+#include <iostream>
+#include <vector>
+#include <cstring>
+
+int main(int argc, char *argv[])
+{
+    if(argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <rom.nes>\n";
+        return 1;
+    }
+
+    std::ifstream rom(argv[1], std::ios::binary);
+    if(!rom) {
+        std::cerr << "Could not open ROM file\n";
+        return 1;
+    }
+
+    uint8_t header[16];
+    rom.read(reinterpret_cast<char*>(header), 16);
+    if(std::strncmp(reinterpret_cast<char*>(header), "NES\x1a", 4) != 0) {
+        std::cerr << "Invalid iNES header\n";
+        return 1;
+    }
+
+    size_t prgSize = header[4] * 16384;
+    std::vector<uint8_t> prg(prgSize);
+    rom.read(reinterpret_cast<char*>(prg.data()), prgSize);
+
+    NesBus bus(prg);
+    c6502 cpu(bus);
+
+    cpu.setReset(true);
+    cpu.setReset(false);
+
+    for(int i = 0; i < 100000; ++i) {
+        cpu.handleInstruction();
+        if(cpu.isIncompatible())
+            break;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add `NesBus` implementing a simple NES memory bus
- create `main.cpp` with basic iNES ROM loading and CPU loop
- provide `Makefile` to build a small emulator

## Testing
- `make clean && make`
- `./nes_emulator`

------
https://chatgpt.com/codex/tasks/task_e_6854dd8b2c7483249609c52befe27333