### PR TITLE
Add basic NES emulator skeleton with SDL2

### DIFF
--- a/APU.h
+++ b/APU.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+
+// Implementaci\u00f3n b\u00e1sica del APU. Solo se define la interfaz.
+class APU {
+public:
+    void cpuWrite(uint16_t addr, uint8_t data) {}
+    uint8_t cpuRead(uint16_t addr) { return 0; }
+
+    void clock(int cycles) {}
+};
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.5)
+project(NESemulator)
+
+set(CMAKE_CXX_STANDARD 17)
+
+find_package(SDL2 REQUIRED)
+include_directories(${SDL2_INCLUDE_DIRS})
+
+add_executable(nes
+    main.cpp
+    c6502.cpp
+    Cartridge.cpp
+    NESBus.cpp
+    PPU.cpp
+)
+
+target_link_libraries(nes ${SDL2_LIBRARIES})
+

--- a/Cartridge.cpp
+++ b/Cartridge.cpp
@@ -1,0 +1,69 @@
+#include "Cartridge.h"
+
+#include <fstream>
+
+bool Cartridge::load(const std::string &path) {
+    std::ifstream f(path, std::ios::binary);
+    if(!f)
+        return false;
+
+    uint8_t header[16];
+    f.read((char*)header, 16);
+    if(f.gcount()!=16)
+        return false;
+
+    if(header[0] != 'N' || header[1] != 'E' || header[2] != 'S' || header[3] != 0x1a)
+        return false;
+
+    uint8_t prg_chunks = header[4];
+    uint8_t chr_chunks = header[5];
+    mapper_id = (header[6] >> 4) | (header[7] & 0xF0);
+    mirroring_vertical = header[6] & 0x01;
+
+    prg_rom.resize(prg_chunks * 0x4000);
+    f.read((char*)prg_rom.data(), prg_rom.size());
+
+    if(chr_chunks == 0)
+        chr_mem.resize(0x2000); // CHR RAM
+    else {
+        chr_mem.resize(chr_chunks * 0x2000);
+        f.read((char*)chr_mem.data(), chr_mem.size());
+    }
+
+    return true;
+}
+
+uint8_t Cartridge::readPRG(uint16_t addr) const {
+    if(prg_rom.empty()) return 0;
+
+    if(prg_rom.size() == 0x4000) // 16KB
+        addr &= 0x3FFF; // espejo
+    else
+        addr &= 0x7FFF;
+
+    return prg_rom[addr];
+}
+
+void Cartridge::writePRG(uint16_t addr, uint8_t data) {
+    // NROM es solo lectura, pero se permite para expansiones
+    if(prg_rom.size() == 0x4000)
+        addr &= 0x3FFF;
+    else
+        addr &= 0x7FFF;
+
+    if(addr < prg_rom.size())
+        prg_rom[addr] = data;
+}
+
+uint8_t Cartridge::readCHR(uint16_t addr) const {
+    if(chr_mem.empty()) return 0;
+    addr &= (chr_mem.size()-1);
+    return chr_mem[addr];
+}
+
+void Cartridge::writeCHR(uint16_t addr, uint8_t data) {
+    if(chr_mem.empty()) return;
+    addr &= (chr_mem.size()-1);
+    chr_mem[addr] = data;
+}
+

--- a/Cartridge.h
+++ b/Cartridge.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Clase que representa un cartucho NES y se encarga de cargar la ROM
+class Cartridge {
+public:
+    // Carga una ROM en formato iNES desde disco
+    bool load(const std::string &path);
+
+    // Lectura y escritura desde la memoria PRG
+    uint8_t readPRG(uint16_t addr) const;
+    void writePRG(uint16_t addr, uint8_t data);
+
+    // Acceso a la memoria CHR utilizada por la PPU
+    uint8_t readCHR(uint16_t addr) const;
+    void writeCHR(uint16_t addr, uint8_t data);
+
+    uint8_t mapper() const { return mapper_id; }
+    bool mirroring() const { return mirroring_vertical; }
+
+private:
+    std::vector<uint8_t> prg_rom;
+    std::vector<uint8_t> chr_mem;
+    uint8_t mapper_id = 0;
+    bool mirroring_vertical = false;
+};
+

--- a/NESBus.cpp
+++ b/NESBus.cpp
@@ -1,0 +1,41 @@
+#include "NESBus.h"
+#include "c6502.h"
+
+NESBus::NESBus() {
+    cpu_ram.fill(0);
+}
+
+void NESBus::insertCartridge(Cartridge* cart) {
+    cartridge = cart;
+    ppu.connect(cart);
+}
+
+uint8_t NESBus::read(c6502* cpu, Addr addr, bool sync) {
+    addr &= 0xFFFF;
+    if(addr <= 0x1FFF) {
+        return cpu_ram[addr & 0x07FF];
+    } else if(addr >= 0x2000 && addr < 0x4000) {
+        return ppu.cpuRead(0x2000 + (addr & 7));
+    } else if(addr >= 0x4000 && addr < 0x4020) {
+        return apu.cpuRead(addr);
+    } else if(addr >= 0x8000) {
+        if(cartridge)
+            return cartridge->readPRG(addr - 0x8000);
+    }
+    return 0;
+}
+
+void NESBus::write(c6502* cpu, Addr addr, uint8_t data) {
+    addr &= 0xFFFF;
+    if(addr <= 0x1FFF) {
+        cpu_ram[addr & 0x07FF] = data;
+    } else if(addr >= 0x2000 && addr < 0x4000) {
+        ppu.cpuWrite(0x2000 + (addr & 7), data);
+    } else if(addr >= 0x4000 && addr < 0x4020) {
+        apu.cpuWrite(addr, data);
+    } else if(addr >= 0x8000) {
+        if(cartridge)
+            cartridge->writePRG(addr - 0x8000, data);
+    }
+}
+

--- a/NESBus.h
+++ b/NESBus.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Bus.h"
+#include "Cartridge.h"
+#include "PPU.h"
+#include "APU.h"
+
+#include <array>
+
+// Bus que conecta CPU, PPU, APU y cartucho
+class NESBus : public Bus {
+public:
+    NESBus();
+
+    void insertCartridge(Cartridge* cart);
+
+    // Implementaci\u00f3n de Bus
+    uint8_t read(c6502* cpu, Addr address, bool sync=false) override;
+    void write(c6502* cpu, Addr address, uint8_t data) override;
+
+    PPU ppu;
+    APU apu;
+
+private:
+    Cartridge* cartridge = nullptr;
+    std::array<uint8_t, 2048> cpu_ram{}; // RAM interna
+
+    // Entrada de mandos
+    uint8_t controller_state[2]{};
+};
+

--- a/PPU.cpp
+++ b/PPU.cpp
@@ -1,0 +1,39 @@
+#include "PPU.h"
+#include "Cartridge.h"
+
+#include <cstring>
+
+PPU::PPU() {
+    tbl_name.resize(2048);
+    tbl_palette.resize(32);
+    framebuffer.resize(256*240, 0xFF000000); // negro opaco
+}
+
+void PPU::connect(Cartridge* c) {
+    cart = c;
+}
+
+uint8_t PPU::cpuRead(uint16_t addr) {
+    // En esta implementaci\u00f3n simple solo devolvemos 0
+    return 0;
+}
+
+void PPU::cpuWrite(uint16_t addr, uint8_t data) {
+    // A\u00fan no implementado
+}
+
+void PPU::clock(int cycles) {
+    // Para simplificar, cada cuadro tiene 341*262 ciclos de PPU
+    for(int i=0;i<cycles;i++) {
+        cycle++;
+        if(cycle >= 341) {
+            cycle = 0;
+            scanline++;
+            if(scanline >= 262) {
+                scanline = 0;
+                frame_complete = true;
+            }
+        }
+    }
+}
+

--- a/PPU.h
+++ b/PPU.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+class Cartridge;
+
+// Emulaci\u00f3n simplificada de la PPU Ricoh 2C02
+class PPU {
+public:
+    PPU();
+
+    void connect(Cartridge* cart);
+
+    // Acceso de la CPU a los registros de la PPU
+    uint8_t cpuRead(uint16_t addr);
+    void cpuWrite(uint16_t addr, uint8_t data);
+
+    // Avanza n ciclos de PPU
+    void clock(int cycles);
+
+    // Indica si hay un cuadro completo listo para dibujar
+    bool frameReady() const { return frame_complete; }
+
+    // Devuelve el framebuffer actual (256x240 pixeles en formato ARGB)
+    const std::vector<uint32_t>& frameBuffer() const { return framebuffer; }
+
+private:
+    Cartridge* cart = nullptr;
+
+    // Memoria interna de la PPU
+    std::vector<uint8_t> tbl_name;   // 2KB de VRAM de nombres
+    std::vector<uint8_t> tbl_palette; // 32 bytes de paleta
+
+    std::vector<uint32_t> framebuffer;
+
+    int scanline = 0;
+    int cycle = 0;
+    bool frame_complete = false;
+};
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Emulador NES sencillo
+
+Este proyecto contiene un emulador b\u00e1sico de la consola Nintendo Entertainment System escrito en C++.
+
+## Compilaci\u00f3n
+
+Se utiliza CMake y la biblioteca SDL2.
+
+En distribuciones Linux:
+
+```bash
+sudo apt-get install libsdl2-dev cmake g++
+mkdir build && cd build
+cmake ..
+make
+```
+
+En Windows con MinGW se puede usar `mingw32-make` y una instalaci\u00f3n de SDL2.
+
+El programa se ejecuta pasando la ruta a una ROM en formato `.nes`:
+
+```bash
+./nes juego.nes
+```
+

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,60 @@
+#include "c6502.h"
+#include "NESBus.h"
+#include "Cartridge.h"
+
+#include <SDL2/SDL.h>
+#include <iostream>
+
+int main(int argc, char* argv[]) {
+    if(argc < 2) {
+        std::cout << "Uso: " << argv[0] << " <rom.nes>\n";
+        return 0;
+    }
+
+    Cartridge cart;
+    if(!cart.load(argv[1])) {
+        std::cerr << "No se pudo cargar la ROM\n";
+        return 1;
+    }
+
+    NESBus bus;
+    bus.insertCartridge(&cart);
+    c6502 cpu(bus);
+
+    if(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) != 0) {
+        std::cerr << "Error inicializando SDL2\n";
+        return 1;
+    }
+
+    SDL_Window* win = SDL_CreateWindow("NES", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+                                       256, 240, 0);
+    SDL_Renderer* ren = SDL_CreateRenderer(win, -1, SDL_RENDERER_ACCELERATED);
+    SDL_Texture* tex = SDL_CreateTexture(ren, SDL_PIXELFORMAT_ARGB8888,
+                                         SDL_TEXTUREACCESS_STREAMING, 256, 240);
+
+    bool running = true;
+    while(running) {
+        SDL_Event e;
+        while(SDL_PollEvent(&e)) {
+            if(e.type == SDL_QUIT)
+                running = false;
+        }
+
+        cpu.handleInstruction();
+        bus.ppu.clock(3); // aproximado
+
+        if(bus.ppu.frameReady()) {
+            SDL_UpdateTexture(tex, nullptr, bus.ppu.frameBuffer().data(), 256*4);
+            SDL_RenderClear(ren);
+            SDL_RenderCopy(ren, tex, nullptr, nullptr);
+            SDL_RenderPresent(ren);
+        }
+    }
+
+    SDL_DestroyTexture(tex);
+    SDL_DestroyRenderer(ren);
+    SDL_DestroyWindow(win);
+    SDL_Quit();
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add skeleton of NES emulator (Cartridge, PPU, APU, NESBus)
- create basic SDL2 main loop and CMake build files
- include build instructions in README

## Testing
- `cmake ..` *(fails: Could not find SDL2 package)*

------
https://chatgpt.com/codex/tasks/task_e_6855b17cacb08324b1541c01dcbe76cf