### PR TITLE
Add CMake-based NES emulator skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.10)
+project(NesEmu CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(SDL2 REQUIRED)
+include_directories(include ${SDL2_INCLUDE_DIRS})
+
+file(GLOB SOURCES src/*.cpp)
+
+add_executable(nesemu ${SOURCES})
+
+target_link_libraries(nesemu SDL2::SDL2)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# NES Emulator Skeleton
+
+This project provides an initial modular structure for a NES emulator in C++17.
+It uses SDL2 for graphics and input. The current implementation is a starting
+point which loads a ROM and sets up the CPU, memory and a basic PPU.
+
+## Building
+
+```
+mkdir build
+cd build
+cmake ..
+make
+```
+
+Run the emulator with a NES ROM:
+
+```
+./nesemu path/to/rom.nes
+```
+
+## Project Structure
+
+- `include/` – public headers (CPU, PPU, memory, ROM loader).
+- `src/` – implementations and main program.
+
+The CPU class implements a 6502 compatible core. Memory mapping and the PPU are
+kept simple to focus on a working base.

--- a/include/bus.h
+++ b/include/bus.h
@@ -1,3 +1,4 @@
+// Abstract CPU bus interface
 #pragma once
 
 #include <cstdint>

--- a/include/cpu.h
+++ b/include/cpu.h
@@ -1,6 +1,7 @@
+// 6502 CPU implementation
 #pragma once
 
-#include "Bus.h"
+#include "bus.h"
 
 #include <stdint.h>
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -1,0 +1,22 @@
+// CPU memory map implementation for Mapper 0
+#pragma once
+
+#include <cstdint>
+#include <vector>
+#include "cpu.h"
+#include "ppu.h"
+
+class Rom;
+
+class Memory : public Bus {
+public:
+    Memory(PPU& ppu, Rom& rom);
+
+    uint8_t read(c6502* cpu, Addr address, bool sync = false) override;
+    void write(c6502* cpu, Addr address, uint8_t data) override;
+
+private:
+    PPU& ppu;
+    Rom& rom;
+    std::vector<uint8_t> ram;
+};

--- a/include/ppu.h
+++ b/include/ppu.h
@@ -1,0 +1,18 @@
+// Basic PPU placeholder class
+#pragma once
+
+#include <cstdint>
+#include <SDL2/SDL.h>
+
+class PPU {
+public:
+    PPU();
+    ~PPU();
+
+    void reset();
+    void clock();
+    void renderFrame(SDL_Renderer* renderer);
+
+private:
+    uint32_t framebuffer[256 * 240];
+};

--- a/include/rom.h
+++ b/include/rom.h
@@ -1,0 +1,12 @@
+// Simple iNES ROM loader
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+struct Rom {
+    std::vector<uint8_t> prg;
+    std::vector<uint8_t> chr;
+    bool load(const std::string& path);
+};

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -1,4 +1,4 @@
-#include "c6502.h"
+#include "cpu.h"
 
 #include <cassert>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,40 @@
+#include <SDL2/SDL.h>
+#include "cpu.h"
+#include "memory.h"
+#include "rom.h"
+#include "ppu.h"
+#include <iostream>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cout << "Usage: nesemu <rom.nes>\n";
+        return 1;
+    }
+
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_EVENTS) != 0) {
+        std::cerr << "SDL init failed: " << SDL_GetError() << "\n";
+        return 1;
+    }
+
+    SDL_Window* window = SDL_CreateWindow("NES", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED,
+                                          256, 240, SDL_WINDOW_SHOWN);
+    SDL_Renderer* renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+
+    Rom rom;
+    if (!rom.load(argv[1])) {
+        std::cerr << "Failed to load ROM\n";
+        return 1;
+    }
+
+    PPU ppu;
+    Memory mem(ppu, rom);
+    c6502 cpu(mem);
+
+    cpu.setReset(true);
+    cpu.runCpu(); // Note: infinite loop; for skeleton only
+
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+    return 0;
+}

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -1,0 +1,26 @@
+#include "memory.h"
+#include "rom.h"
+
+Memory::Memory(PPU& ppu_, Rom& rom_) : ppu(ppu_), rom(rom_), ram(2 * 1024, 0) {}
+
+uint8_t Memory::read(c6502* cpu, Addr addr, bool sync) {
+    (void)cpu; (void)sync;
+    if (addr < 0x2000) {
+        return ram[addr & 0x07FF];
+    } else if (addr < 0x4000) {
+        // PPU registers mirror every 8
+        return 0; // placeholder
+    } else if (addr >= 0x8000) {
+        return rom.prg[addr - 0x8000];
+    }
+    return 0;
+}
+
+void Memory::write(c6502* cpu, Addr addr, uint8_t data) {
+    (void)cpu;
+    if (addr < 0x2000) {
+        ram[addr & 0x07FF] = data;
+    } else if (addr < 0x4000) {
+        // write to PPU register
+    }
+}

--- a/src/ppu.cpp
+++ b/src/ppu.cpp
@@ -1,0 +1,20 @@
+#include "ppu.h"
+
+PPU::PPU() { reset(); }
+PPU::~PPU() {}
+
+void PPU::reset() {
+    for (auto &p : framebuffer) p = 0x000000FF; // black
+}
+
+void PPU::clock() {
+    // Placeholder for PPU cycles
+}
+
+void PPU::renderFrame(SDL_Renderer* renderer) {
+    SDL_Texture* texture = SDL_CreateTexture(renderer, SDL_PIXELFORMAT_ARGB8888,
+                                             SDL_TEXTUREACCESS_STREAMING, 256, 240);
+    SDL_UpdateTexture(texture, nullptr, framebuffer, 256 * sizeof(uint32_t));
+    SDL_RenderCopy(renderer, texture, nullptr, nullptr);
+    SDL_DestroyTexture(texture);
+}

--- a/src/rom.cpp
+++ b/src/rom.cpp
@@ -1,0 +1,18 @@
+#include "rom.h"
+#include <fstream>
+
+bool Rom::load(const std::string& path) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file) return false;
+    uint8_t header[16];
+    file.read((char*)header, 16);
+    if (header[0] != 'N' || header[1] != 'E' || header[2] != 'S')
+        return false;
+    size_t prg_size = header[4] * 16384;
+    size_t chr_size = header[5] * 8192;
+    prg.resize(prg_size);
+    chr.resize(chr_size);
+    file.read((char*)prg.data(), prg_size);
+    file.read((char*)chr.data(), chr_size);
+    return true;
+}


### PR DESCRIPTION
## Summary
- set up modular folders (`src/`, `include/`)
- provide initial CMakeLists.txt and README
- add placeholder PPU, ROM loader and memory mapper
- move existing 6502 CPU code into new structure
- create main program using SDL2

## Testing
- `cmake ..` *(fails: FindSDL2.cmake missing)*

------
https://chatgpt.com/codex/tasks/task_e_685d9de762d08324b24a1cd7386778c3