### PR TITLE
Add basic NES emulator skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.app
+nesemu

--- a/APU.h
+++ b/APU.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <cstdint>
+
+// Minimal stub for APU. Does not produce sound.
+class APU {
+public:
+    uint8_t readRegister(uint16_t addr) { (void)addr; return 0; }
+    void writeRegister(uint16_t addr, uint8_t data) { (void)addr; (void)data; }
+};

--- a/Controller.h
+++ b/Controller.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <cstdint>
+
+// Simple controller handling 8 buttons
+class Controller {
+public:
+    // Button order: A B Select Start Up Down Left Right
+    void setState(uint8_t state) { buttons = state; shift = state; }
+
+    uint8_t read() {
+        uint8_t ret = (shift & 0x80) ? 1 : 0;
+        shift <<= 1;
+        return ret | 0x40; // open bus high bits set
+    }
+
+    void write(uint8_t value) {
+        if(value & 1)
+            shift = buttons;
+    }
+
+private:
+    uint8_t buttons = 0; // bitmask
+    uint8_t shift = 0;
+};

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+CXX=g++
+CXXFLAGS=-std=c++17 -Wall -Wextra -O2
+
+OBJS=c6502.o NesBus.o PPU.o main.o
+
+all: nesemu
+
+nesemu: $(OBJS)
+	$(CXX) $(CXXFLAGS) -o $@ $(OBJS)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) nesemu
+
+.PHONY: all clean

--- a/NesBus.cpp
+++ b/NesBus.cpp
@@ -1,0 +1,77 @@
+#include "NesBus.h"
+#include "PPU.h"
+#include <fstream>
+#include <iostream>
+
+NesBus::NesBus() {}
+NesBus::~NesBus() {}
+
+bool NesBus::loadROM(const std::string &path) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f)
+        return false;
+
+    std::vector<uint8_t> header(16);
+    f.read(reinterpret_cast<char*>(header.data()), 16);
+    if (header[0] != 'N' || header[1] != 'E' || header[2] != 'S' || header[3] != 0x1A)
+        return false;
+
+    size_t prgSize = header[4] * 16384; // 16KB units
+    size_t chrSize = header[5] * 8192;  // 8KB units
+
+    prgROM.resize(prgSize);
+    f.read(reinterpret_cast<char*>(prgROM.data()), prgSize);
+
+    chrROM.resize(chrSize);
+    if (chrSize)
+        f.read(reinterpret_cast<char*>(chrROM.data()), chrSize);
+
+    if (ppu)
+        ppu->loadCHR(chrROM);
+
+    return true;
+}
+
+uint8_t NesBus::read(c6502 *cpu, Addr addr, bool sync) {
+    addr &= 0xFFFF;
+    if (addr < 0x2000) {
+        // internal RAM mirrored every 2KB
+        return ram[addr & 0x07FF];
+    } else if (addr < 0x4000) {
+        // PPU registers mirrored every 8 bytes
+        if (ppu)
+            return ppu->readRegister(0x2000 + (addr & 7));
+        return 0;
+    } else if (addr < 0x4020) {
+        // APU / IO. Only controller for now
+        if (ctrl && addr == 0x4016)
+            return ctrl->read();
+        return 0;
+    } else if (addr >= 0x8000) {
+        // PRG ROM (NROM only, 16K or 32K)
+        size_t index = addr - 0x8000;
+        if (prgROM.size() == 16384 && addr >= 0xC000)
+            index = addr - 0xC000; // mirror if 16K
+        if (index < prgROM.size())
+            return prgROM[index];
+        return 0;
+    }
+    // other ranges: return open bus
+    return 0;
+}
+
+void NesBus::write(c6502 *cpu, Addr addr, uint8_t data) {
+    addr &= 0xFFFF;
+    if (addr < 0x2000) {
+        ram[addr & 0x07FF] = data;
+    } else if (addr < 0x4000) {
+        if (ppu)
+            ppu->writeRegister(0x2000 + (addr & 7), data);
+    } else if (addr < 0x4020) {
+        if (ctrl && addr == 0x4016)
+            ctrl->write(data);
+    } else if (addr >= 0x6000 && addr < 0x8000) {
+        sram[addr - 0x6000] = data;
+    }
+    // writes to ROM are ignored
+}

--- a/NesBus.h
+++ b/NesBus.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "Bus.h"
+#include "c6502.h"
+#include <array>
+#include "Controller.h"
+#include <vector>
+#include <string>
+
+// Forward declarations for NES components
+class PPU;
+class APU;
+class Controller;
+
+// NES addressable memory bus implementing mapper 0 (NROM)
+class NesBus : public Bus {
+public:
+    NesBus();
+    ~NesBus();
+
+    // Load iNES ROM into memory. Returns true on success.
+    bool loadROM(const std::string &path);
+
+    uint8_t read(c6502 *cpu, Addr addr, bool sync = false) override;
+    void write(c6502 *cpu, Addr addr, uint8_t data) override;
+
+    PPU    *ppu  = nullptr;
+    APU    *apu  = nullptr;
+    Controller *ctrl = nullptr;
+
+private:
+    std::vector<uint8_t> prgROM;   // PRG ROM data
+    std::vector<uint8_t> chrROM;   // CHR ROM data (for PPU)
+
+    std::array<uint8_t, 0x0800> ram{};      // 2KB internal RAM
+    std::array<uint8_t, 0x2000> sram{};     // optional battery RAM
+};

--- a/PPU.cpp
+++ b/PPU.cpp
@@ -1,0 +1,15 @@
+#include "PPU.h"
+
+void PPU::loadCHR(const std::vector<uint8_t> &chr) {
+    chrROM = chr;
+}
+
+uint8_t PPU::readRegister(uint16_t addr) {
+    addr &= 7;
+    return registers[addr];
+}
+
+void PPU::writeRegister(uint16_t addr, uint8_t value) {
+    addr &= 7;
+    registers[addr] = value;
+}

--- a/PPU.h
+++ b/PPU.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <array>
+#include <vector>
+#include <cstdint>
+
+// Very small placeholder implementation of the NES PPU. It stores
+// registers and character ROM data but does not fully emulate graphics.
+class PPU {
+public:
+    void loadCHR(const std::vector<uint8_t> &chr);
+
+    uint8_t readRegister(uint16_t addr);
+    void writeRegister(uint16_t addr, uint8_t value);
+
+private:
+    std::array<uint8_t, 8> registers{};
+    std::vector<uint8_t> chrROM;
+};

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,37 @@
+#include "c6502.h"
+#include "NesBus.h"
+#include "PPU.h"
+#include "APU.h"
+#include "Controller.h"
+#include <iostream>
+
+int main(int argc, char **argv) {
+    if (argc < 2) {
+        std::cout << "Usage: " << argv[0] << " <rom.nes>\n";
+        return 1;
+    }
+
+    PPU ppu;
+    APU apu;
+    Controller ctrl;
+    NesBus bus;
+    bus.ppu = &ppu;
+    bus.apu = &apu;
+    bus.ctrl = &ctrl;
+
+    if(!bus.loadROM(argv[1])) {
+        std::cerr << "Failed to load ROM\n";
+        return 1;
+    }
+
+    c6502 cpu(bus);
+    cpu.resetSequence();
+
+    // run for a limited number of cycles as example
+    for(int i=0;i<1000;i++) {
+        cpu.handleInstruction();
+    }
+
+    std::cout << "Finished." << std::endl;
+    return 0;
+}


### PR DESCRIPTION
## Summary
- implement `NesBus` memory map and ROM loader
- add stub `PPU`, `APU`, and `Controller` classes
- create `main.cpp` to load ROM and run CPU
- provide a simple Makefile for building
- ignore generated binary

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_686eabdf24f08324bd5ce86b6e13f873