### PR TITLE
Add basic modular NES emulator skeleton

### DIFF
--- a/APU.cpp
+++ b/APU.cpp
@@ -1,0 +1,1 @@
+#include "APU.h"

--- a/APU.h
+++ b/APU.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <cstdint>
+class APU {
+public:
+    void reset() {}
+    void clock() {}
+    uint8_t readRegister(uint16_t) { return 0; }
+    void writeRegister(uint16_t, uint8_t) {}
+};

--- a/Bus.h
+++ b/Bus.h
@@ -4,10 +4,10 @@
 
 using Addr = uint16_t;
 
-class c6502;
+class CPU6502;
 
 class Bus {
 public:
-    virtual uint8_t read( c6502 *cpu, Addr address, bool sync = false ) = 0;
-    virtual void write( c6502 *cpu, Addr address, uint8_t ) = 0;
+    virtual uint8_t read( CPU6502 *cpu, Addr address, bool sync = false ) = 0;
+    virtual void write( CPU6502 *cpu, Addr address, uint8_t ) = 0;
 };

--- a/CPU6502.cpp
+++ b/CPU6502.cpp
@@ -1,0 +1,976 @@
+#include "CPU6502.h"
+
+#include <cassert>
+
+#include <iostream>
+
+static Addr compose(uint8_t high, uint8_t low) {
+    return high<<8 | low;
+}
+
+void CPU6502::runCpu() {
+    while(true) {
+        try {
+            if( reset_pending )
+                resetSequence();
+            else
+                handleInstruction();
+        } catch( CpuReset ex ) {
+        }
+    }
+}
+
+void CPU6502::setReset(bool state) {
+    reset = state;
+    if( state )
+        reset_pending = true;
+
+    std::cout<<"CPU reset "<<state<<"\n";
+}
+void CPU6502::setIrq(bool state) {
+    irq = state;
+    std::cout<<"CPU IRQ "<<state<<"\n";
+}
+void CPU6502::setNmi(bool state) {
+    if( !nmi && state )
+        nmi_pending = true;
+
+    nmi = state;
+    std::cout<<"CPU NMI "<<state<<"\n";
+}
+void CPU6502::setReady(bool state) {
+    ready = state;
+    std::cout<<"CPU ready "<<state<<"\n";
+}
+void CPU6502::setSo(bool state) {
+    if( !so && state )
+        ccSet( CC::oVerflow, true );
+    so = state;
+    std::cout<<"CPU SO "<<state<<"\n";
+}
+
+
+void CPU6502::handleInstruction() {
+    if( nmi_pending ) {
+        handleNmi();
+    }
+
+    if( irq ) {
+        handleIrq();
+    }
+
+    if( delayed_ops!=DelayedOps::None ) {
+        ccSet(CC::IntMask, delayed_ops==DelayedOps::SEI);
+
+        delayed_ops = DelayedOps::None;
+    }
+
+    current_opcode = read( pc(), true );
+
+    advance_pc();
+
+    switch(current_opcode) {
+    case 0x00: op_brk( addrmode_immediate() );                  break;
+    case 0x01: op_ora( addrmode_zp_x_ind() );                   break;
+    case 0x05: op_ora( addrmode_zp() );                         break;
+    case 0x06: op_asl( addrmode_zp() );                         break;
+    case 0x08: op_php( addrmode_stack() );                      break;
+    case 0x09: op_ora( addrmode_immediate() );                  break;
+    case 0x0a: op_aslA();                                       break;
+    case 0x0d: op_ora( addrmode_abs() );                        break;
+    case 0x0e: op_asl( addrmode_abs() );                        break;
+    case 0x10: op_bpl( addrmode_immediate() );                  break;
+    case 0x11: op_ora( addrmode_zp_ind_y() );                   break;
+    case 0x15: op_ora( addrmode_zp_x() );                       break;
+    case 0x16: op_asl( addrmode_zp_x() );                       break;
+    case 0x18: op_clc( addrmode_implicit() );                   break;
+    case 0x19: op_ora( addrmode_abs_y() );                      break;
+    case 0x1a: op_incA( addrmode_implicit() );                  break;
+    case 0x1d: op_ora( addrmode_abs_x() );                      break;
+    case 0x1e: op_asl( addrmode_abs_x(true) );                  break;
+    case 0x20: op_jsr( addrmode_special() );                    break;
+    case 0x21: op_and( addrmode_zp_x_ind() );                   break;
+    case 0x24: op_bit( addrmode_zp() );                         break;
+    case 0x25: op_and( addrmode_zp() );                         break;
+    case 0x26: op_rol( addrmode_zp() );                         break;
+    case 0x28: op_plp( addrmode_stack() );                      break;
+    case 0x29: op_and( addrmode_immediate() );                  break;
+    case 0x2a: op_rolA();                                       break;
+    case 0x2c: op_bit( addrmode_abs() );                        break;
+    case 0x2d: op_and( addrmode_abs() );                        break;
+    case 0x2e: op_rol( addrmode_abs() );                        break;
+    case 0x30: op_bmi( addrmode_immediate() );                  break;
+    case 0x31: op_and( addrmode_zp_ind_y() );                   break;
+    case 0x34: op_bit( addrmode_zp_x() );                       break;
+    case 0x35: op_and( addrmode_zp_x() );                       break;
+    case 0x36: op_rol( addrmode_zp_x() );                       break;
+    case 0x38: op_sec( addrmode_implicit() );                   break;
+    case 0x39: op_and( addrmode_abs_y() );                      break;
+    case 0x3a: op_decA( addrmode_implicit() );                  break;
+    case 0x3c: op_bit( addrmode_abs_x() );                      break;
+    case 0x3d: op_and( addrmode_abs_x() );                      break;
+    case 0x3e: op_rol( addrmode_abs_x(true) );                  break;
+    case 0x40: op_rti( addrmode_stack() );                      break;
+    case 0x41: op_eor( addrmode_zp_x_ind() );                   break;
+    case 0x45: op_eor( addrmode_zp() );                         break;
+    case 0x46: op_lsr( addrmode_zp() );                         break;
+    case 0x48: op_pha( addrmode_stack() );                      break;
+    case 0x49: op_eor( addrmode_immediate() );                  break;
+    case 0x4a: op_lsrA();                                       break;
+    case 0x4c: op_jmp( addrmode_abs() );                        break;
+    case 0x4d: op_eor( addrmode_abs() );                        break;
+    case 0x4e: op_lsr( addrmode_abs() );                        break;
+    case 0x50: op_bvc( addrmode_immediate() );                  break;
+    case 0x51: op_eor( addrmode_zp_ind_y() );                   break;
+    case 0x52: op_eor( addrmode_zp_ind() );                     break;
+    case 0x55: op_eor( addrmode_zp_x() );                       break;
+    case 0x56: op_lsr( addrmode_zp_x() );                       break;
+    case 0x58: op_cli( addrmode_implicit() );                   break;
+    case 0x59: op_eor( addrmode_abs_y() );                      break;
+    case 0x5d: op_eor( addrmode_abs_x() );                      break;
+    case 0x5e: op_lsr( addrmode_abs_x() );                      break;
+    case 0x60: op_rts( addrmode_stack() );                      break;
+    case 0x61: op_adc( addrmode_zp_x_ind() );                   break;
+    case 0x65: op_adc( addrmode_zp() );                         break;
+    case 0x66: op_ror( addrmode_zp() );                         break;
+    case 0x68: op_pla( addrmode_stack() );                      break;
+    case 0x69: op_adc( addrmode_immediate() );                  break;
+    case 0x6a: op_rorA();                                       break;
+    case 0x6c: op_jmp( addrmode_abs_ind() );                    break;
+    case 0x6d: op_adc( addrmode_abs() );                        break;
+    case 0x6e: op_ror( addrmode_abs() );                        break;
+    case 0x70: op_bvs( addrmode_immediate() );                  break;
+    case 0x71: op_adc( addrmode_zp_ind_y() );                   break;
+    case 0x75: op_adc( addrmode_zp_x() );                       break;
+    case 0x76: op_ror( addrmode_zp_x() );                       break;
+    case 0x78: op_sei( addrmode_implicit() );                   break;
+    case 0x79: op_adc( addrmode_abs_y() );                      break;
+    case 0x7d: op_adc( addrmode_abs_x() );                      break;
+    case 0x7e: op_ror( addrmode_abs_x(true) );                  break;
+    case 0x81: op_sta( addrmode_zp_x_ind() );                   break;
+    case 0x84: op_sty( addrmode_zp() );                         break;
+    case 0x85: op_sta( addrmode_zp() );                         break;
+    case 0x86: op_stx( addrmode_zp() );                         break;
+    case 0x88: op_dey( addrmode_implicit() );                   break;
+    case 0x89: op_bit( addrmode_immediate() );                  break;
+    case 0x8a: op_txa();                                        break;
+    case 0x8c: op_sty( addrmode_abs() );                        break;
+    case 0x8d: op_sta( addrmode_abs() );                        break;
+    case 0x8e: op_stx( addrmode_abs() );                        break;
+    case 0x90: op_bcc( addrmode_immediate() );                  break;
+    case 0x91: op_sta( addrmode_zp_ind_y(true) );               break;
+    case 0x92: op_sta( addrmode_zp_ind() );                     break;
+    case 0x94: op_sty( addrmode_zp_x() );                       break;
+    case 0x95: op_sta( addrmode_zp_x() );                       break;
+    case 0x96: op_stx( addrmode_zp_y() );                       break;
+    case 0x98: op_tya();                                        break;
+    case 0x99: op_sta( addrmode_abs_y(true) );                  break;
+    case 0x9a: op_txs();                                        break;
+    case 0x9d: op_sta( addrmode_abs_x(true) );                  break;
+    case 0xa0: op_ldy( addrmode_immediate() );                  break;
+    case 0xa2: op_ldx( addrmode_immediate() );                  break;
+    case 0xa4: op_ldy( addrmode_zp() );                         break;
+    case 0xa5: op_lda( addrmode_zp() );                         break;
+    case 0xa6: op_ldx( addrmode_zp() );                         break;
+    case 0xa8: op_tay();                                        break;
+    case 0xa9: op_lda( addrmode_immediate() );                  break;
+    case 0xaa: op_tax();                                        break;
+    case 0xac: op_ldy( addrmode_abs() );                        break;
+    case 0xad: op_lda( addrmode_abs() );                        break;
+    case 0xae: op_ldx( addrmode_abs() );                        break;
+    case 0xb0: op_bcs( addrmode_immediate() );                  break;
+    case 0xb1: op_lda( addrmode_zp_ind_y() );                   break;
+    case 0xb4: op_ldy( addrmode_zp_x() );                       break;
+    case 0xb5: op_lda( addrmode_zp_x() );                       break;
+    case 0xb6: op_ldx( addrmode_zp_y() );                       break;
+    case 0xb8: op_clv( addrmode_implicit() );                   break;
+    case 0xb9: op_lda( addrmode_abs_y() );                      break;
+    case 0xba: op_tsx();                                        break;
+    case 0xbc: op_ldy( addrmode_abs_x() );                      break;
+    case 0xbd: op_lda( addrmode_abs_x() );                      break;
+    case 0xbe: op_ldx( addrmode_abs_y() );                      break;
+    case 0xc0: op_cpy( addrmode_immediate() );                  break;
+    case 0xc1: op_cmp( addrmode_zp_x_ind() );                   break;
+    case 0xc4: op_cpy( addrmode_zp() );                         break;
+    case 0xc5: op_cmp( addrmode_zp() );                         break;
+    case 0xc6: op_dec( addrmode_zp() );                         break;
+    case 0xc8: op_iny( addrmode_implicit() );                   break;
+    case 0xc9: op_cmp( addrmode_immediate() );                  break;
+    case 0xca: op_dex( addrmode_implicit() );                   break;
+    case 0xcc: op_cpy( addrmode_abs() );                        break;
+    case 0xcd: op_cmp( addrmode_abs() );                        break;
+    case 0xce: op_dec( addrmode_abs() );                        break;
+    case 0xd0: op_bne( addrmode_immediate() );                  break;
+    case 0xd1: op_cmp( addrmode_zp_ind_y() );                   break;
+    case 0xd2: op_cmp( addrmode_zp_ind() );                     break;
+    case 0xd5: op_cmp( addrmode_zp_x() );                       break;
+    case 0xd6: op_dec( addrmode_zp_x() );                       break;
+    case 0xd8: op_cld( addrmode_implicit() );                   break;
+    case 0xd9: op_cmp( addrmode_abs_y() );                      break;
+    case 0xdd: op_cmp( addrmode_abs_x() );                      break;
+    case 0xde: op_dec( addrmode_abs_x() );                      break;
+    case 0xe0: op_cpx( addrmode_immediate() );                  break;
+    case 0xe1: op_sbc( addrmode_zp_x_ind() );                   break;
+    case 0xe4: op_cpx( addrmode_zp() );                         break;
+    case 0xe5: op_sbc( addrmode_zp() );                         break;
+    case 0xe6: op_inc( addrmode_zp() );                         break;
+    case 0xe8: op_inx( addrmode_implicit() );                   break;
+    case 0xe9: op_sbc( addrmode_immediate() );                  break;
+    case 0xea: op_nop( addrmode_implicit() );                   break;
+    case 0xec: op_cpx( addrmode_abs() );                        break;
+    case 0xed: op_sbc( addrmode_abs() );                        break;
+    case 0xee: op_inc( addrmode_abs() );                        break;
+    case 0xf0: op_beq( addrmode_immediate() );                  break;
+    case 0xf1: op_sbc( addrmode_zp_ind_y() );                   break;
+    case 0xf5: op_sbc( addrmode_zp_x() );                       break;
+    case 0xf6: op_inc( addrmode_zp_x() );                       break;
+    case 0xf8: op_sed( addrmode_implicit() );                   break;
+    case 0xf9: op_sbc( addrmode_abs_y() );                      break;
+    case 0xfd: op_sbc( addrmode_abs_x() );                      break;
+    case 0xfe: op_inc( addrmode_abs_x() );                      break;
+    default: std::cerr<<"Comando desconocido "<<std::hex<<int(current_opcode)<<" at "<<(pc()-1)<<"\n"; abort();
+    }
+}
+
+void CPU6502::resetSequence() {
+    incompatible = true;
+    while( reset ) {
+        read( pc() );
+    }
+
+    reset_pending = false;
+
+    incompatible = true;
+    read( pc() );
+    advance_pc();
+
+    incompatible = true;
+    read( pc() );
+
+    assert( !incompatible );
+
+    read( compose( 0x01, regSp-- ) );
+    read( compose( 0x01, regSp-- ) );
+    read( compose( 0x01, regSp-- ) );
+
+    regPcL = read(0xfffc);
+    regPcH = read(0xfffd);
+
+    ccSet( CC::IntMask, true );
+}
+
+void CPU6502::advance_pc() {
+    Addr pc_ = pc();
+    pc_++;
+    regPcH = pc_>>8;
+    regPcL = pc_ & 0xff;
+}
+
+Addr CPU6502::pc() const {
+    return compose(regPcH, regPcL);
+}
+
+uint8_t CPU6502::read( Addr address, bool sync ) {
+    uint8_t result;
+    do {
+        result = bus_.read( this, address, sync );
+    } while(ready);
+
+    incompatible = false;
+
+    if( reset_pending ) {
+        incompatible = true;
+        while( reset )
+            bus_.read( this, address );
+
+        throw CpuReset();
+    }
+
+    return result;
+}
+
+void CPU6502::write( Addr address, uint8_t data ) {
+    if( reset_pending ) {
+        incompatible = true;
+
+        while( reset )
+            bus_.read( this, address );
+
+        throw CpuReset();
+    }
+
+    do {
+        bus_.write( this, address, data );
+    } while(ready);
+
+    incompatible = false;
+}
+
+
+uint8_t CPU6502::ccGet( CC cc ) const {
+    return bool( regStatus & (1<<int(cc)) );
+}
+
+void CPU6502::ccSet( CC cc, bool value ) {
+    if( value ) {
+        regStatus |= 1<<int(cc);
+    } else {
+        regStatus &= ~( 1<<int(cc) );
+    }
+}
+
+void CPU6502::handleNmi() {
+    nmi_pending = false;
+
+    read( pc() );
+    read( pc() );
+
+    write( compose( 0x01, regSp-- ), regPcH );
+    write( compose( 0x01, regSp-- ), regPcL );
+    write( compose( 0x01, regSp-- ), regStatus & 0xef );
+
+    ccSet( CC::IntMask, true );
+
+    regPcL = read( 0xfffa );
+    regPcH = read( 0xfffb );
+}
+
+void CPU6502::handleIrq() {
+    if( ccGet( CC::IntMask ) )
+        return;
+
+    read( pc() );
+    read( pc() );
+
+    write( compose( 0x01, regSp-- ), regPcH );
+    write( compose( 0x01, regSp-- ), regPcL );
+    write( compose( 0x01, regSp-- ), regStatus & 0xef );
+
+    ccSet( CC::IntMask, true );
+
+    regPcL = read( 0xfffe );
+    regPcH = read( 0xffff );
+}
+
+// Address modes
+Addr CPU6502::addrmode_abs() {
+    Addr res = read( pc() );
+    advance_pc();
+    res |= read( pc() ) << 8;
+    advance_pc();
+
+    return res;
+}
+
+Addr CPU6502::addrmode_abs_ind() {
+    uint8_t addrL = read( pc() );
+    advance_pc();
+    uint8_t addrH = read( pc() );
+    advance_pc();
+
+    Addr res = read( compose( addrH, addrL++ ) );
+    res |= read( compose( addrH, addrL ) )<<8;
+
+    return res;
+}
+
+Addr CPU6502::addrmode_abs_x(bool always_waste_cycle) {
+    Addr resL = read( pc() );
+    advance_pc();
+    Addr resH = read( pc() ) << 8;
+    resL += regX;
+    advance_pc();
+
+    if( resL>>8 != 0 || always_waste_cycle ) {
+        read( compose( resH>>8, resL&0xff ) );
+    }
+
+    return resL + resH;
+}
+
+Addr CPU6502::addrmode_abs_y(bool always_waste_cycle) {
+    Addr resL = read( pc() );
+    advance_pc();
+    Addr resH = read( pc() ) << 8;
+    resL += regY;
+    advance_pc();
+
+    if( always_waste_cycle || resL>>8 != 0 ) {
+        read( compose( resH>>8, resL&0xff ) );
+    }
+
+    return resL + resH;
+}
+
+Addr CPU6502::addrmode_immediate() {
+    Addr stored_pc = pc();
+    advance_pc();
+
+    return stored_pc;
+}
+
+Addr CPU6502::addrmode_implicit() {
+    read( pc() );
+
+    return pc();
+}
+
+Addr CPU6502::addrmode_special() {
+    return pc();
+}
+
+Addr CPU6502::addrmode_stack() {
+    read( pc() );
+
+    return compose( 0x01, regSp );
+}
+
+Addr CPU6502::addrmode_zp() {
+    uint8_t addr = read( pc() );
+    advance_pc();
+
+    return addr;
+}
+
+Addr CPU6502::addrmode_zp_ind() {
+    uint8_t addr = read( pc() );
+    advance_pc();
+
+    Addr res_lsb = read(addr);
+
+    Addr res_msb = read( (addr+1) & 0xff );
+
+    return res_lsb + res_msb*256;
+}
+
+Addr CPU6502::addrmode_zp_ind_y(bool always_waste_cycle) {
+    uint8_t addr = read( pc() );
+    advance_pc();
+
+    Addr res_lsb = read(addr);
+
+    res_lsb += regY;
+    Addr res_msb = read( (addr+1) & 0xff );
+
+    if( always_waste_cycle || res_lsb>>8 != 0 ) {
+        read( compose( res_msb, res_lsb&0xff ) );
+    }
+
+    return res_lsb + res_msb*256;
+}
+
+Addr CPU6502::addrmode_zp_x() {
+    uint8_t addr = read( pc() );
+    advance_pc();
+
+    read(addr);
+
+    return (addr + regX) & 0xff;
+}
+
+Addr CPU6502::addrmode_zp_x_ind() {
+    uint8_t zp = read( pc() );
+    advance_pc();
+
+    read(zp);
+    zp += regX;
+    zp &= 0xff;
+
+    Addr addr = read(zp);
+
+    zp++;
+    zp &= 0xff;
+
+    addr |= read(zp) << 8;
+
+    return addr;
+}
+
+Addr CPU6502::addrmode_zp_y() {
+    uint8_t addr = read( pc() );
+    advance_pc();
+
+    read(addr);
+
+    return (addr + regY) & 0xff;
+}
+
+void CPU6502::branch_helper(Addr addr, bool jump) {
+    int8_t offset = read(addr);
+
+    if( jump ) {
+        read( pc() );
+
+        uint16_t program_counter = pc();
+        program_counter += offset;
+
+        regPcL = program_counter & 0xff;
+
+        if( regPcH != (program_counter>>8) ) {
+            read( pc() );
+            regPcH = program_counter >> 8;
+        }
+    }
+}
+
+void CPU6502::op_adc(Addr addr) {
+    uint16_t val = read(addr);
+
+    bool sameSign = (val & 0x80) == (regA & 0x80);
+
+    val += regA + (ccGet( CC::Carry ) ? 1 : 0);
+
+    bool stillSameSign = (val & 0x80) == (regA & 0x80);
+
+    ccSet( CC::oVerflow, sameSign && !stillSameSign );
+
+    regA = val;
+
+    ccSet( CC::Carry, val & 0x100 );
+    updateNZ( val );
+}
+
+void CPU6502::op_and(Addr addr) {
+    regA &= read(addr);
+
+    updateNZ( regA );
+}
+
+void CPU6502::op_asl(Addr addr) {
+    uint16_t val = read(addr);
+    write(addr, val);
+    val <<= 1;
+
+    ccSet( CC::Carry, val&0x100 );
+
+    updateNZ( val );
+
+    write(addr, val);
+}
+
+void CPU6502::op_aslA() {
+    read( pc() );
+
+    uint16_t val = regA;
+
+    val<<=1;
+
+    ccSet( CC::Carry, val&0x100 );
+
+    updateNZ( val );
+
+    regA = val;
+}
+
+void CPU6502::op_bcc(Addr addr) {
+    branch_helper(addr, ! ccGet(CC::Carry));
+}
+
+void CPU6502::op_bcs(Addr addr) {
+    branch_helper(addr, ccGet(CC::Carry));
+}
+
+void CPU6502::op_beq(Addr addr) {
+    branch_helper(addr, ccGet(CC::Zero));
+}
+
+void CPU6502::op_bit(Addr addr) {
+    uint8_t mem = read(addr);
+    uint8_t result = regA ^ mem;
+
+    ccSet( CC::Negative, mem & 0x80 );
+    ccSet( CC::oVerflow, mem & 0x40 );
+    ccSet( CC::Zero, result==0 );
+}
+
+void CPU6502::op_bne(Addr addr) {
+    branch_helper(addr, ! ccGet(CC::Zero));
+}
+
+void CPU6502::op_bmi(Addr addr) {
+    branch_helper(addr, ccGet(CC::Negative));
+}
+
+void CPU6502::op_bpl(Addr addr) {
+    branch_helper(addr, ! ccGet(CC::Negative));
+}
+
+
+void CPU6502::op_brk(Addr addr) {
+    read(addr);
+
+    write( compose(0x01, regSp--), regPcH );
+    write( compose(0x01, regSp--), regPcL );
+    write( compose(0x01, regSp--), regStatus );
+
+    regPcL = read( 0xfffe );
+    regPcH = read( 0xffff );
+
+    ccSet( CC::IntMask, true );
+}
+
+void CPU6502::op_bvc(Addr addr) {
+    branch_helper(addr, ! ccGet(CC::oVerflow));
+}
+
+void CPU6502::op_bvs(Addr addr) {
+    branch_helper(addr, ccGet(CC::oVerflow));
+}
+
+void CPU6502::op_clc(Addr addr) {
+    ccSet( CC::Carry, false );
+}
+
+void CPU6502::op_cld(Addr addr) {
+    ccSet( CC::Decimal, false );
+}
+
+void CPU6502::op_cli(Addr addr) {
+    delayed_ops = DelayedOps::CLI;
+}
+
+void CPU6502::op_clv(Addr addr) {
+    ccSet( CC::oVerflow, false );
+}
+
+void CPU6502::op_cmp(Addr addr) {
+    uint16_t calc = 0x100 | regA;
+    calc -= read(addr);
+
+    ccSet( CC::Carry, calc & 0x100 );
+    updateNZ( calc );
+}
+
+void CPU6502::op_cpx(Addr addr) {
+    uint16_t calc = 0x100 | regX;
+    calc -= read(addr);
+
+    updateNZ( calc );
+    ccSet( CC::Carry, calc & 0x100 );
+}
+
+void CPU6502::op_cpy(Addr addr) {
+    uint16_t calc = 0x100 | regY;
+    calc -= read(addr);
+
+    updateNZ( calc );
+    ccSet( CC::Carry, calc & 0x100 );
+}
+
+void CPU6502::op_dec(Addr addr) {
+    uint8_t res = read(addr);
+    write(addr, res);
+
+    res--;
+    write(addr, res);
+
+    updateNZ( res );
+}
+
+void CPU6502::op_decA(Addr addr) {
+    regX--;
+
+    updateNZ( regX );
+}
+
+void CPU6502::op_dex(Addr addr) {
+    regX--;
+
+    updateNZ( regX );
+}
+
+void CPU6502::op_dey(Addr addr) {
+    regY--;
+
+    updateNZ( regY );
+}
+
+void CPU6502::op_eor(Addr addr) {
+    regA ^= read(addr);
+
+    updateNZ( regA );
+}
+
+void CPU6502::op_inc(Addr addr) {
+    uint8_t val = read(addr);
+
+    write(addr, val);
+    write(addr, ++val);
+
+    updateNZ( val );
+}
+
+void CPU6502::op_incA(Addr addr) {
+    regA++;
+
+    updateNZ( regA );
+}
+
+void CPU6502::op_inx(Addr addr) {
+    regX++;
+
+    updateNZ( regX );
+}
+
+void CPU6502::op_iny(Addr addr) {
+    regY++;
+
+    updateNZ( regY );
+}
+
+void CPU6502::op_jmp(Addr addr) {
+    regPcL = addr & 0xff;
+    regPcH = addr >> 8;
+}
+
+void CPU6502::op_jsr(Addr addr) {
+    uint8_t dest_low = read( pc() );
+    advance_pc();
+
+    read( compose( 0x01, regSp ) );
+    write( compose( 0x01, regSp-- ), regPcH );
+    write( compose( 0x01, regSp-- ), regPcL );
+
+    regPcH = read( pc() );
+    regPcL = dest_low;
+}
+
+void CPU6502::op_lda(Addr addr) {
+    regA = read( addr );
+
+    updateNZ( regA );
+}
+
+void CPU6502::op_ldx(Addr addr) {
+    regX = read( addr );
+
+    updateNZ( regX );
+}
+
+void CPU6502::op_ldy(Addr addr) {
+    regY = read( addr );
+
+    updateNZ( regY );
+}
+
+void CPU6502::op_lsr(Addr addr) {
+    uint8_t val = read(addr);
+    write(addr, val);
+
+    ccSet( CC::Carry, val&0x01 );
+    val >>= 1;
+
+    updateNZ( val );
+
+    write(addr, val);
+}
+
+void CPU6502::op_lsrA() {
+    read( pc() );
+
+    ccSet( CC::Carry, regA&0x01 );
+
+    regA >>= 1;
+
+    updateNZ( regA );
+}
+
+void CPU6502::op_nop(Addr addr) {
+}
+
+void CPU6502::op_ora(Addr addr) {
+    regA |= read(addr);
+
+    updateNZ( regA );
+}
+
+
+void CPU6502::op_pha(Addr addr) {
+    write( addr, regA );
+
+    regSp--;
+}
+
+void CPU6502::op_php(Addr addr) {
+    write( addr, regStatus );
+
+    regSp--;
+}
+
+void CPU6502::op_pla(Addr addr) {
+    read( addr );
+
+    regSp++;
+    regA = read( compose( 0x01, regSp ) );
+
+    updateNZ( regA );
+}
+
+void CPU6502::op_plp(Addr addr) {
+    read( addr );
+
+    regSp++;
+    regStatus = read( compose( 0x01, regSp ) ) | 0x30;
+}
+
+void CPU6502::op_rol(Addr addr) {
+    uint16_t value = read( addr );
+    write( addr, value );
+
+    value <<= 1;
+    value |= ccGet( CC::Carry );
+    ccSet( CC::Carry, value & 0x100 );
+    updateNZ( value );
+
+    write( addr, value );
+}
+
+void CPU6502::op_rolA() {
+    read( pc() );
+
+    bool newC = regA & 0x80;
+    regA <<= 1;
+    if( ccGet( CC::Carry ) )
+        regA |= 0x01;
+
+    ccSet( CC::Carry, newC );
+    updateNZ( regA );
+}
+
+void CPU6502::op_ror(Addr addr) {
+    uint8_t value = read( addr );
+    write( addr, value );
+
+    bool newC = value & 0x01;
+    value >>= 1;
+    value |= ccGet( CC::Carry ) ? 0x80 : 0x00;
+    ccSet( CC::Carry, newC );
+    updateNZ( value );
+
+    write( addr, value );
+}
+
+void CPU6502::op_rorA() {
+    read( pc() );
+
+    bool newC = regA & 0x01;
+    regA >>= 1;
+    regA |= ccGet( CC::Carry ) ? 0x80 : 0x00;
+    ccSet( CC::Carry, newC );
+    updateNZ( regA );
+
+}
+
+void CPU6502::op_rti(Addr addr) {
+    read( addr );
+    regSp++;
+
+    regStatus = read( compose(0x01, regSp++) ) | 0x30;
+
+    regPcL = read( compose(0x01, regSp++) );
+    regPcH = read( compose(0x01, regSp) );
+}
+
+void CPU6502::op_rts(Addr addr) {
+    read( compose(0x01, regSp++) );
+
+    regPcL = read( compose(0x01, regSp++) );
+    regPcH = read( compose(0x01, regSp) );
+
+    read( pc() );
+    advance_pc();
+}
+
+void CPU6502::op_sbc(Addr addr) {
+    uint8_t val = read(addr);
+
+    uint16_t res = regA - val;
+    if( !ccGet( CC::Carry ) )
+        res--;
+
+    bool sameSign = (val & 0x80) == (regA & 0x80);
+    bool stillSameSign = (val & 0x80) == (res & 0x80);
+
+    regA = res;
+
+    ccSet( CC::oVerflow, !sameSign && stillSameSign );
+
+    updateNZ( regA );
+    ccSet( CC::Carry, (res & 0x100)==0 );
+}
+
+void CPU6502::op_sec(Addr addr) {
+    ccSet( CC::Carry, true );
+}
+
+void CPU6502::op_sed(Addr addr) {
+    ccSet( CC::Decimal, true );
+}
+
+void CPU6502::op_sei(Addr addr) {
+    delayed_ops = DelayedOps::SEI;
+}
+
+void CPU6502::op_sta(Addr addr) {
+    write( addr, regA );
+}
+
+void CPU6502::op_stx(Addr addr) {
+    write( addr, regX );
+}
+
+void CPU6502::op_sty(Addr addr) {
+    write( addr, regY );
+}
+
+void CPU6502::op_tax() {
+    read( pc() );
+
+    regX = regA;
+
+    updateNZ( regA );
+}
+
+void CPU6502::op_tay() {
+    read( pc() );
+
+    regY = regA;
+
+    updateNZ( regA );
+}
+
+void CPU6502::op_tsx() {
+    read( pc() );
+
+    regX = regSp;
+
+    updateNZ( regX );
+}
+
+
+void CPU6502::op_txa() {
+    read( pc() );
+
+    regA = regX;
+
+    updateNZ( regA );
+}
+
+void CPU6502::op_txs() {
+    read( pc() );
+
+    regSp = regX;
+}
+
+void CPU6502::op_tya() {
+    read( pc() );
+
+    regA = regY;
+
+    updateNZ( regA );
+}
+
+void CPU6502::updateNZ(uint8_t val) {
+    ccSet( CC::Negative, val & 0x80 );
+    ccSet( CC::Zero, val == 0 );
+}

--- a/CPU6502.h
+++ b/CPU6502.h
@@ -1,0 +1,151 @@
+#pragma once
+
+#include "Bus.h"
+
+#include <stdint.h>
+
+class CPU6502 {
+    class CpuReset {};
+
+    enum class DelayedOps { None, SEI, CLI } delayed_ops = DelayedOps::None;
+
+    Bus &bus_;
+
+    uint8_t regA, regX, regY;
+    uint8_t regSp;
+    uint8_t regStatus = 0xff;
+    uint8_t regPcL, regPcH;
+
+    uint8_t current_opcode;
+
+    bool reset = false, irq = false, nmi = false, ready = false, so = false;
+    bool reset_pending = false, nmi_pending = false;
+    bool incompatible = false;
+
+    enum class CC {
+        Carry,
+        Zero,
+        IntMask,
+        Decimal,
+        NA,
+        NA2,
+        oVerflow,
+        Negative
+    };
+
+public:
+    explicit CPU6502(Bus &bus) : bus_(bus) {}
+
+    
+    void setReset(bool state);
+    void setIrq(bool state);
+    void setNmi(bool state);
+    void setReady(bool state);
+    void setSo(bool state);
+    void resetSequence();
+    void handleInstruction();
+    void runCpu();
+    // Returns true if this cycle is knowningly incompatible
+    bool isIncompatible() const { return incompatible; }
+
+private:
+    
+    
+    void advance_pc();
+
+    Addr pc() const;
+
+    uint8_t read( Addr address, bool sync = false );
+    void write( Addr address, uint8_t data );
+
+    uint8_t ccGet( CC cc ) const;
+    void ccSet( CC cc, bool value );
+
+    void handleNmi();
+    void handleIrq();
+
+    void branch_helper(Addr addr, bool jump);
+
+    // Address modes
+    Addr addrmode_abs();
+    Addr addrmode_abs_ind();
+    Addr addrmode_abs_x(bool always_waste_cycle = false);
+    Addr addrmode_abs_y(bool always_waste_cycle = false);
+    Addr addrmode_immediate();
+    Addr addrmode_implicit();
+    Addr addrmode_stack();
+    Addr addrmode_zp();
+    Addr addrmode_zp_ind();
+    Addr addrmode_zp_ind_y(bool always_waste_cycle = false);
+    Addr addrmode_zp_x();
+    Addr addrmode_zp_x_ind();
+    Addr addrmode_zp_y();
+    Addr addrmode_special();
+
+
+    // Operations
+    void op_adc(Addr addr);
+    void op_and(Addr addr);
+    void op_asl(Addr addr);
+    void op_aslA();
+    void op_bcc(Addr addr);
+    void op_bcs(Addr addr);
+    void op_beq(Addr addr);
+    void op_bit(Addr addr);
+    void op_bmi(Addr addr);
+    void op_bne(Addr addr);
+    void op_bpl(Addr addr);
+    void op_brk(Addr addr);
+    void op_bvc(Addr addr);
+    void op_bvs(Addr addr);
+    void op_clc(Addr addr);
+    void op_cld(Addr addr);
+    void op_cli(Addr addr);
+    void op_clv(Addr addr);
+    void op_cmp(Addr addr);
+    void op_cpx(Addr addr);
+    void op_cpy(Addr addr);
+    void op_dec(Addr addr);
+    void op_decA(Addr addr);
+    void op_dex(Addr addr);
+    void op_dey(Addr addr);
+    void op_eor(Addr addr);
+    void op_inc(Addr addr);
+    void op_incA(Addr addr);
+    void op_inx(Addr addr);
+    void op_iny(Addr addr);
+    void op_jmp(Addr addr);
+    void op_jsr(Addr addr);
+    void op_lda(Addr addr);
+    void op_ldx(Addr addr);
+    void op_ldy(Addr addr);
+    void op_lsr(Addr addr);
+    void op_lsrA();
+    void op_nop(Addr addr);
+    void op_ora(Addr addr);
+    void op_pha(Addr addr);
+    void op_php(Addr addr);
+    void op_pla(Addr addr);
+    void op_plp(Addr addr);
+    void op_rol(Addr addr);
+    void op_rolA();
+    void op_ror(Addr addr);
+    void op_rorA();
+    void op_rti(Addr addr);
+    void op_rts(Addr addr);
+    void op_sbc(Addr addr);
+    void op_sec(Addr addr);
+    void op_sed(Addr addr);
+    void op_sei(Addr addr);
+    void op_sta(Addr addr);
+    void op_stx(Addr addr);
+    void op_sty(Addr addr);
+    void op_tax();
+    void op_tay();
+    void op_tsx();
+    void op_txa();
+    void op_txs();
+    void op_tya();
+
+    void updateNZ(uint8_t val);
+};

--- a/Controller.cpp
+++ b/Controller.cpp
@@ -1,0 +1,29 @@
+#include "Controller.h"
+
+void Controller::update(const SDL_Event& ev) {
+    if (ev.type == SDL_EVENT_KEY_DOWN || ev.type == SDL_EVENT_KEY_UP) {
+        bool pressed = ev.type == SDL_EVENT_KEY_DOWN;
+        switch(ev.key.keysym.sym) {
+            case SDLK_a: state = pressed ? (state|0x01) : (state&~0x01); break; // A
+            case SDLK_s: state = pressed ? (state|0x02) : (state&~0x02); break; // B
+            case SDLK_SPACE: state = pressed ? (state|0x04) : (state&~0x04); break; // Select
+            case SDLK_RETURN: state = pressed ? (state|0x08) : (state&~0x08); break; // Start
+            case SDLK_UP: state = pressed ? (state|0x10) : (state&~0x10); break;
+            case SDLK_DOWN: state = pressed ? (state|0x20) : (state&~0x20); break;
+            case SDLK_LEFT: state = pressed ? (state|0x40) : (state&~0x40); break;
+            case SDLK_RIGHT: state = pressed ? (state|0x80) : (state&~0x80); break;
+        }
+    }
+}
+
+uint8_t Controller::read() {
+    uint8_t val = (latched & 0x80) ? 1 : 0;
+    latched <<= 1;
+    return val;
+}
+
+void Controller::write(uint8_t data) {
+    if (data & 1) {
+        latched = state;
+    }
+}

--- a/Controller.h
+++ b/Controller.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <cstdint>
+#include <SDL3/SDL.h>
+
+class Controller {
+    uint8_t state = 0;
+    uint8_t latched = 0;
+public:
+    void update(const SDL_Event& ev);
+    uint8_t read();
+    void write(uint8_t data);
+};

--- a/IMapper.h
+++ b/IMapper.h
@@ -1,0 +1,13 @@
+#pragma once
+#include <cstdint>
+#include <vector>
+
+// Interface for NES cartridge mappers
+class IMapper {
+public:
+    virtual ~IMapper() = default;
+    virtual uint8_t readPRG(uint16_t addr) = 0;
+    virtual void writePRG(uint16_t addr, uint8_t data) = 0;
+    virtual uint8_t readCHR(uint16_t addr) = 0;
+    virtual void writeCHR(uint16_t addr, uint8_t data) = 0;
+};

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+CXX=g++
+CXXFLAGS=-std=c++17 $(shell sdl3-config --cflags)
+LDFLAGS=$(shell sdl3-config --libs)
+OBJS=main.o CPU6502.o NesBus.o PPU.o APU.o Controller.o Mapper0.o Mapper1.o Mapper2.o Mapper3.o Mapper4.o
+
+all: nes_emulator
+
+nes_emulator: $(OBJS)
+	$(CXX) $(OBJS) -o $@ $(LDFLAGS)
+
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) -c $< -o $@
+
+clean:
+	rm -f $(OBJS) nes_emulator

--- a/Mapper0.cpp
+++ b/Mapper0.cpp
@@ -1,0 +1,36 @@
+#include "MapperRegistry.h"
+#include "IMapper.h"
+#include <vector>
+
+// Basic NROM mapper
+class Mapper0 : public IMapper {
+    std::vector<uint8_t> prg;
+    std::vector<uint8_t> chr;
+public:
+    Mapper0(const std::vector<uint8_t>& p, const std::vector<uint8_t>& c)
+        : prg(p), chr(c) {}
+
+    uint8_t readPRG(uint16_t addr) override {
+        addr &= (prg.size() - 1);
+        return prg[addr];
+    }
+    void writePRG(uint16_t addr, uint8_t data) override {
+        addr &= (prg.size() - 1);
+        prg[addr] = data;
+    }
+    uint8_t readCHR(uint16_t addr) override {
+        addr &= (chr.size() - 1);
+        return chr[addr];
+    }
+    void writeCHR(uint16_t addr, uint8_t data) override {
+        addr &= (chr.size() - 1);
+        chr[addr] = data;
+    }
+};
+
+// Factory function used by registration system
+extern "C" IMapper* createMapper0(const std::vector<uint8_t>& prg,
+                                   const std::vector<uint8_t>& chr) {
+    return new Mapper0(prg, chr);
+}
+REGISTER_MAPPER(0, Mapper0);

--- a/Mapper1.cpp
+++ b/Mapper1.cpp
@@ -1,0 +1,14 @@
+#include "MapperRegistry.h"
+#include "IMapper.h"
+#include <vector>
+
+class Mapper1 : public IMapper {
+    std::vector<uint8_t> prg, chr;
+public:
+    Mapper1(const std::vector<uint8_t>& p,const std::vector<uint8_t>& c):prg(p),chr(c){}
+    uint8_t readPRG(uint16_t a) override { return prg[a%prg.size()]; }
+    void writePRG(uint16_t, uint8_t) override {}
+    uint8_t readCHR(uint16_t a) override { return chr[a%chr.size()]; }
+    void writeCHR(uint16_t, uint8_t) override {}
+};
+REGISTER_MAPPER(1, Mapper1);

--- a/Mapper2.cpp
+++ b/Mapper2.cpp
@@ -1,0 +1,14 @@
+#include "MapperRegistry.h"
+#include "IMapper.h"
+#include <vector>
+
+class Mapper2 : public IMapper {
+    std::vector<uint8_t> prg, chr;
+public:
+    Mapper2(const std::vector<uint8_t>& p,const std::vector<uint8_t>& c):prg(p),chr(c){}
+    uint8_t readPRG(uint16_t a) override { return prg[a%prg.size()]; }
+    void writePRG(uint16_t, uint8_t) override {}
+    uint8_t readCHR(uint16_t a) override { return chr[a%chr.size()]; }
+    void writeCHR(uint16_t, uint8_t) override {}
+};
+REGISTER_MAPPER(2, Mapper2);

--- a/Mapper3.cpp
+++ b/Mapper3.cpp
@@ -1,0 +1,14 @@
+#include "MapperRegistry.h"
+#include "IMapper.h"
+#include <vector>
+
+class Mapper3 : public IMapper {
+    std::vector<uint8_t> prg, chr;
+public:
+    Mapper3(const std::vector<uint8_t>& p,const std::vector<uint8_t>& c):prg(p),chr(c){}
+    uint8_t readPRG(uint16_t a) override { return prg[a%prg.size()]; }
+    void writePRG(uint16_t, uint8_t) override {}
+    uint8_t readCHR(uint16_t a) override { return chr[a%chr.size()]; }
+    void writeCHR(uint16_t, uint8_t) override {}
+};
+REGISTER_MAPPER(3, Mapper3);

--- a/Mapper4.cpp
+++ b/Mapper4.cpp
@@ -1,0 +1,14 @@
+#include "MapperRegistry.h"
+#include "IMapper.h"
+#include <vector>
+
+class Mapper4 : public IMapper {
+    std::vector<uint8_t> prg, chr;
+public:
+    Mapper4(const std::vector<uint8_t>& p,const std::vector<uint8_t>& c):prg(p),chr(c){}
+    uint8_t readPRG(uint16_t a) override { return prg[a%prg.size()]; }
+    void writePRG(uint16_t, uint8_t) override {}
+    uint8_t readCHR(uint16_t a) override { return chr[a%chr.size()]; }
+    void writeCHR(uint16_t, uint8_t) override {}
+};
+REGISTER_MAPPER(4, Mapper4);

--- a/MapperRegistry.h
+++ b/MapperRegistry.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "IMapper.h"
+#include <map>
+#include <functional>
+#include <vector>
+
+class MapperRegistry {
+public:
+    using Maker = std::function<IMapper*(const std::vector<uint8_t>&, const std::vector<uint8_t>&)>;
+    static std::map<uint8_t, Maker>& registry() {
+        static std::map<uint8_t, Maker> inst;
+        return inst;
+    }
+    static void registerMapper(uint8_t id, Maker m) {
+        registry()[id] = m;
+    }
+};
+
+// Helper macros to register mappers
+#define REGISTER_MAPPER(ID, TYPE) \
+    namespace { struct Reg##TYPE { Reg##TYPE(){ MapperRegistry::registerMapper(ID, \
+        [](const std::vector<uint8_t>& p,const std::vector<uint8_t>& c){ return new TYPE(p,c); }); }} reg##TYPE; }

--- a/NesBus.cpp
+++ b/NesBus.cpp
@@ -1,0 +1,43 @@
+#include "NesBus.h"
+#include <fstream>
+
+NesBus::NesBus() : cpu(*this) {}
+
+bool NesBus::loadROM(const std::string& path) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) return false;
+    std::array<uint8_t,16> header{};
+    f.read((char*)header.data(),16);
+    if (header[0] != 'N' || header[1] != 'E' || header[2] != 'S') return false;
+    uint8_t prgBanks = header[4];
+    uint8_t chrBanks = header[5];
+    uint8_t mapperID = (header[6] >> 4) | (header[7] & 0xF0);
+    std::vector<uint8_t> prg(prgBanks*16384);
+    std::vector<uint8_t> chr(chrBanks?chrBanks*8192:8192);
+    f.read((char*)prg.data(), prg.size());
+    f.read((char*)chr.data(), chr.size());
+    auto it = MapperRegistry::registry().find(mapperID);
+    if (it == MapperRegistry::registry().end()) return false;
+    mapper.reset(it->second(prg, chr));
+    cpu.setReset(true);
+    ppu.reset();
+    apu.reset();
+    return true;
+}
+
+uint8_t NesBus::read(CPU6502*, Addr addr, bool) {
+    if (addr < 0x2000) return ram[addr & 0x7FF];
+    else if (addr < 0x4000) return ppu.readRegister(addr & 7);
+    else if (addr == 0x4016) return pad1.read();
+    else if (addr == 0x4017) return pad2.read();
+    else if (addr >= 0x8000) return mapper ? mapper->readPRG(addr - 0x8000) : 0;
+    return 0;
+}
+
+void NesBus::write(CPU6502*, Addr addr, uint8_t data) {
+    if (addr < 0x2000) ram[addr & 0x7FF] = data;
+    else if (addr < 0x4000) ppu.writeRegister(addr & 7, data);
+    else if (addr == 0x4016) pad1.write(data);
+    else if (addr == 0x4017) pad2.write(data);
+    else if (addr >= 0x8000 && mapper) mapper->writePRG(addr - 0x8000, data);
+}

--- a/NesBus.h
+++ b/NesBus.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "Bus.h"
+#include "CPU6502.h"
+#include "PPU.h"
+#include "APU.h"
+#include "Controller.h"
+#include "MapperRegistry.h"
+#include <memory>
+#include <string>
+#include <array>
+
+class NesBus : public Bus {
+    std::array<uint8_t, 2048> ram{};
+public:
+    CPU6502 cpu;
+    PPU ppu;
+    APU apu;
+    Controller pad1, pad2;
+    std::unique_ptr<IMapper> mapper;
+
+    NesBus();
+    bool loadROM(const std::string& path);
+
+    uint8_t read(CPU6502* cpu, Addr addr, bool sync=false) override;
+    void write(CPU6502* cpu, Addr addr, uint8_t data) override;
+};

--- a/PPU.cpp
+++ b/PPU.cpp
@@ -1,0 +1,30 @@
+#include "PPU.h"
+
+void PPU::reset() {
+    scanline = cycle = 0;
+    nmiFlag = false;
+    framebuffer.fill(0xff000000);
+}
+
+void PPU::clock() {
+    cycle++;
+    if (cycle >= 341) {
+        cycle = 0;
+        scanline++;
+        if (scanline >= 262) {
+            scanline = 0;
+            nmiFlag = true; // signal VBlank
+        }
+    }
+}
+
+bool PPU::pollNMI() {
+    if (nmiFlag) {
+        nmiFlag = false;
+        return true;
+    }
+    return false;
+}
+
+uint8_t PPU::readRegister(uint16_t) { return 0; }
+void PPU::writeRegister(uint16_t, uint8_t) {}

--- a/PPU.h
+++ b/PPU.h
@@ -1,0 +1,17 @@
+#pragma once
+#include <array>
+#include <cstdint>
+
+class PPU {
+    std::array<uint32_t, 256*240> framebuffer{};
+    int scanline = 0;
+    int cycle = 0;
+    bool nmiFlag = false;
+public:
+    void reset();
+    void clock();
+    bool pollNMI();
+    uint8_t readRegister(uint16_t addr);
+    void writeRegister(uint16_t addr, uint8_t data);
+    uint32_t* getFrameBuffer() { return framebuffer.data(); }
+};

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,46 @@
+#include "NesBus.h"
+#include <SDL3/SDL.h>
+#include <cstdio>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        printf("Usage: %s romfile\n", argv[0]);
+        return 0;
+    }
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO) != 0) return 1;
+    SDL_Window* window = SDL_CreateWindow("NES Emulator",
+        256, 240, SDL_WINDOW_BORDERLESS | SDL_WINDOW_ALLOW_HIGHDPI);
+    SDL_Renderer* renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
+    SDL_Texture* texture = SDL_CreateTexture(renderer,
+        SDL_PIXELFORMAT_ARGB8888, SDL_TEXTUREACCESS_STREAMING, 256, 240);
+
+    NesBus nes;
+    if (!nes.loadROM(argv[1])) {
+        printf("Failed to load ROM\n");
+        return 1;
+    }
+
+    bool running = true;
+    while (running) {
+        SDL_Event ev;
+        while (SDL_PollEvent(&ev)) {
+            if (ev.type == SDL_EVENT_QUIT) running = false;
+            nes.pad1.update(ev);
+        }
+
+        // simple CPU/PPU clocking
+        nes.cpu.handleInstruction();
+        for (int i = 0; i < 3; ++i) nes.ppu.clock();
+        if (nes.ppu.pollNMI()) nes.cpu.setNmi(true);
+
+        SDL_UpdateTexture(texture, nullptr, nes.ppu.getFrameBuffer(), 256 * sizeof(uint32_t));
+        SDL_RenderClear(renderer);
+        SDL_RenderTexture(renderer, texture, nullptr, nullptr);
+        SDL_RenderPresent(renderer);
+    }
+    SDL_DestroyTexture(texture);
+    SDL_DestroyRenderer(renderer);
+    SDL_DestroyWindow(window);
+    SDL_Quit();
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add CPU6502 class and port existing CPU code
- implement NesBus connecting CPU, PPU, APU, controllers and mappers
- stub PPU/APU and controllers
- provide mapper interface with basic mappers and registry system
- add SDL3-based main loop and Makefile

## Testing
- `make` *(fails: `sdl3-config` not found and missing SDL headers)*

------
https://chatgpt.com/codex/tasks/task_e_6875767e8ef48324835b6f8411f33ee2